### PR TITLE
fix(test): correct step 170 hint to describe variable assignment

### DIFF
--- a/.freeCodeCamp/test/170.test.js
+++ b/.freeCodeCamp/test/170.test.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const { appendAndRun } = require('./utils');
 
 describe('Your script', () => {
-  it('should "echo" the suggested variable correctly', async () => {
+  it('should have the suggested variable added correctly', async () => {
     const output = await appendAndRun('../questionnaire.sh', 'echo $QUESTION1');
 
     assert(/^What's your name\?$/gm.test(output));


### PR DESCRIPTION
Closes freeCodeCamp/freeCodeCamp#67605

Step 170 asks the camper only to create the `QUESTION1` variable. Its test
description, which is surfaced to campers as the hint on failure, reads
`should "echo" the suggested variable correctly` — identical to the
description in 180.test.js, the step that actually asks for the `echo`.
A camper who mistypes at step 170 is therefore told about an `echo`
statement the step never asked for.

The test logic is correct and unchanged; `appendAndRun` supplies the
`echo` internally to read the variable's value. Only the description is
updated, matching the wording already used by the equivalent
variable-creation steps 230, 340, and 730
("should have the suggested variable added correctly").